### PR TITLE
Fix minor typos and warnings in commented root_ca sections 

### DIFF
--- a/roles.tf
+++ b/roles.tf
@@ -23,6 +23,12 @@ resource "vault_pki_secret_backend_role" "role-server-cer" {
   ttl = 2592000
   no_store = true
 
+  key_usage = [
+    "DigitalSignature",
+    "KeyAgreement",
+    "KeyEncipherment"
+  ]
+
 }
 
 resource "vault_pki_secret_backend_role" "vault-client-cert" {
@@ -48,4 +54,9 @@ resource "vault_pki_secret_backend_role" "vault-client-cert" {
   ttl = 2592000
   no_store = true
 
+  key_usage = [
+    "DigitalSignature",
+    "KeyAgreement",
+    "KeyEncipherment"
+  ]
 }

--- a/root_ca.tf
+++ b/root_ca.tf
@@ -1,4 +1,4 @@
-# Create a mount point for the Root Certiifacte authority.
+# Create a mount point for the Root Certificate authority.
 resource "vault_mount" "root" {
     type = "pki"
     path = "pki-root-ca"

--- a/root_ca.tf
+++ b/root_ca.tf
@@ -20,7 +20,7 @@ resource "vault_pki_secret_backend_config_urls" "config_urls" {
 # CA infrastructure is now tied to vault and pretty much the server 
 # you created the CA on.
 # resource "vault_pki_secret_backend_root_cert" "ca-cert" {
-#   depends_on = ["vault_pki_secret_backend_config_urls.config_urls"]    
+#   depends_on = [vault_pki_secret_backend_config_urls.config_urls]
 #   backend = vault_mount.root.path
 
 #   type = "exported"

--- a/root_ca.tf
+++ b/root_ca.tf
@@ -24,7 +24,7 @@ resource "vault_pki_secret_backend_config_urls" "config_urls" {
 #   backend = vault_mount.root.path
 
 #   type = "exported"
-#   common_name = ${var.server_cert_domain} Root CA"
+#   common_name = "${var.server_cert_domain} Root CA"
 #   ttl = 473040000 #15 Years
 #   format = "pem"
 #   private_key_format = "der"


### PR DESCRIPTION
For my demo purposes I wanted to leverage the root_ca within vault itself, but found a typo (missing quote) and a warning. 

I also added `key_usage` values to the roles to avoid diffs on subsequent `terraform plan` invocations, e.g. this was happening:

```
Terraform will perform the following actions:

  # vault_pki_secret_backend_role.role-server-cer will be updated in-place
  ~ resource "vault_pki_secret_backend_role" "role-server-cer" {
        allow_any_name                     = false
        allow_bare_domains                 = false
        allow_glob_domains                 = false
        allow_ip_sans                      = true
        allow_localhost                    = true
        allow_subdomains                   = true
        allowed_domains                    = [
            "mydomain.com",
        ]
        allowed_other_sans                 = []
        allowed_uri_sans                   = []
        backend                            = "pki-int-ca"
        basic_constraints_valid_for_non_ca = false
        client_flag                        = false
        code_signing_flag                  = false
        country                            = [
            "usa",
        ]
        email_protection_flag              = false
        enforce_hostnames                  = true
        ext_key_usage                      = []
        generate_lease                     = false
        id                                 = "pki-int-ca/roles/server-cert-for-mydomain.com"
        key_bits                           = 2048
        key_type                           = "rsa"
      ~ key_usage                          = [
          - "DigitalSignature",
          - "KeyAgreement",
          - "KeyEncipherment",
        ]
        locality                           = [
            "Beverly Hills",
        ]
        max_ttl                            = "63113904"
        name                               = "server-cert-for-mydomain.com"
        no_store                           = true
        not_before_duration                = "0s"
        organization                       = [
            "My Company",
        ]
        ou                                 = [
            "development",
        ]
        policy_identifiers                 = []
        postal_code                        = []
        province                           = []
        require_cn                         = true
        server_flag                        = true
        street_address                     = []
        ttl                                = "2592000"
        use_csr_common_name                = true
        use_csr_sans                       = true
    }

  # vault_pki_secret_backend_role.vault-client-cert will be updated in-place
  ~ resource "vault_pki_secret_backend_role" "vault-client-cert" {
        allow_any_name                     = false
        allow_bare_domains                 = true
        allow_glob_domains                 = false
        allow_ip_sans                      = true
        allow_localhost                    = true
        allow_subdomains                   = false
        allowed_domains                    = [
            "mydomain.com",
        ]
        allowed_other_sans                 = []
        allowed_uri_sans                   = []
        backend                            = "pki-int-ca"
        basic_constraints_valid_for_non_ca = false
        client_flag                        = true
        code_signing_flag                  = false
        country                            = [
            "usa",
        ]
        email_protection_flag              = false
        enforce_hostnames                  = true
        ext_key_usage                      = []
        generate_lease                     = false
        id                                 = "pki-int-ca/roles/client-cert-for-mydomain.com"
        key_bits                           = 2048
        key_type                           = "rsa"
      ~ key_usage                          = [
          - "DigitalSignature",
          - "KeyAgreement",
          - "KeyEncipherment",
        ]
        locality                           = [
            "Beverly Hills",
        ]
        max_ttl                            = "63113904"
        name                               = "client-cert-for-mydomain.com"
        no_store                           = true
        not_before_duration                = "0s"
        organization                       = [
            "My Company",
        ]
        ou                                 = [
            "development",
        ]
        policy_identifiers                 = []
        postal_code                        = []
        province                           = []
        require_cn                         = true
        server_flag                        = true
        street_address                     = []
        ttl                                = "2592000"
        use_csr_common_name                = true
        use_csr_sans                       = true
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```