### PR TITLE
Update intermediate_ca.tf

### DIFF
--- a/intermediate_ca.tf
+++ b/intermediate_ca.tf
@@ -80,5 +80,5 @@ output "intermediate_ca" {
 }
 
 output "intermediate_key"  {
-    value = "${vault_pki_secret_backend_intermediate_cert_request.intermediate.private_key}"
+    value = vault_pki_secret_backend_intermediate_cert_request.intermediate.private_key
 }


### PR DESCRIPTION
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

by the way, on your blog there is a missing r from terraform
```
Run the Terraform Scripts
In the “client” shell window (that has VAULT_ADDR configured) run:
terrafom init.  <--- terraform init
terraform apply
```

Thanks for the awesome post